### PR TITLE
Use public async module

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "mkdirp": "~0.3.4",
-    "async": "git://github.com/superjoe30/async.git#515c7dfe26135a1961ae9d71c5c"
+    "async": "~0.2.6"
   }
 }


### PR DESCRIPTION
'npm install' fails with a permission denied error to the forked async repo.

It should use the public version for this project anyways.
