### PR TITLE
Allow updating worker count during deploy, added tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ CLI:
 
         Available options and their defaults:
 
+            --worker-count [as-before]
             --override-env true
             --timeout none
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -144,9 +144,10 @@ var cmds = {
 
       "    Available options and their defaults:\n\n" +
 
-      "        --override-env true\n        --timeout none",
+      "        --worker-count [as-before]\n        --override-env true\n        --timeout none",
     fn: function(argv){
       var options = {
+        'worker-count': 0,
         'override-env': 'true',
         'timeout': 'none'
       };
@@ -156,6 +157,8 @@ var cmds = {
       if (!err && argv.length === 0) {
         options['override-env'] = options['override-env'] === 'true';
         options.timeout = parseFloat(options.timeout);
+        if (isNaN(options['worker-count'])) return false;
+        options['new-worker-count'] = Math.floor(eq(options['worker-count'], {cpus: cpuCount}));
         if (isNaN(options.timeout)) {
           options.timeout = null;
         }
@@ -412,6 +415,7 @@ function deploy(options, ipcFile){
       setAbortKeyboardHook();
       json_socket.send(socket, {
         action: 'NaughtDeploy',
+        newWorkerCount: options['new-worker-count'],
         environment: options['override-env'] ? process.env : {},
         timeout: options.timeout
       });

--- a/lib/master.js
+++ b/lib/master.js
@@ -63,6 +63,7 @@ function onNaughtDeployAbort(message) {
 
 function onNaughtDeploy(message) {
   extend(process.env, message.environment);
+  workerCount = (message.newWorkerCount !== 0) ? message.newWorkerCount : workers.online.count;
   var timer = null;
   deployStart(function(eventName){
     if (timer != null) clearTimeout(timer);


### PR DESCRIPTION
@superjoe30 I tried to avoid using "unchange" and instead use 0 for default and get previous count of workers from **_workers.online.count**_ .
I'm not sure COUNT + X or COUNT - Y worth the trouble. I think specifying explicit workers count is straight forward enough, and it would be a very simple add-on to do so from a script:

``` sh
TOTAL_COUNT=`naught status | cut -d" " -f3`
naught deploy --worker-count `expr $TOTAL_COUNT + 1`
```

Hopefully it makes some sense.
