### PR TITLE
Update the readme with details about the cwd option on naught deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,18 @@ CLI:
         `worker-count` can be used to change the number of workers running. A
         value of `0` means to keep the same number of workers.
 
+        `cwd` can be used to change the cwd directory of the master process.
+        This allows you to release in different directories. Unfortunately,
+        this option doesn't update the script location. For example, if you
+        start naught `naught start --cwd /release/1 server.js` and deploy
+        `naught deploy --cwd /release/2` the script file will not change from
+        '/release/1/server.js' to '/release/2/server.js'. You have to create
+        a symlink and pass the full symlink path to naught start
+        '/current/server.js'. After creating the symlink naught starts the
+        correct script, but the cwd is still old and require loads files from
+        from the old directory. The cwd option allows you to update the cwd
+        to the new directory. It defaults to naught's cwd.
+
         Uses `naught.ipc` by default.
 
         Available options and their defaults:

--- a/lib/main.js
+++ b/lib/main.js
@@ -453,7 +453,7 @@ function deploy(options, ipcFile){
         newWorkerCount: options['worker-count'],
         environment: options['override-env'] ? process.env : {},
         timeout: options.timeout,
-        cwd: options.cwd
+        cwd: path.resolve(options.cwd)
       });
     },
     event: function(msg){

--- a/test/test.js
+++ b/test/test.js
@@ -144,7 +144,7 @@ var steps = [
   {
     info: "ability to deploy and pass cwd",
     fn: function (cb) {
-      naughtExec(["deploy", "--cwd", path.resolve('./lib')], {}, function(stdout, stderr, code) {
+      naughtExec(["deploy", "--cwd", '../lib'], {}, function(stdout, stderr, code) {
         assertEqual(stderr,
           "SpawnNew. booting: 1, online: 1, dying: 0, new_online: 0\n" +
           "NewOnline. booting: 0, online: 1, dying: 0, new_online: 1\n" +


### PR DESCRIPTION
This PR also makes sure to resolve the cwd directory if a relative path is sent to naught deploy. #25
