### PR TITLE
Only allow non-dying servers to send an offline message

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -179,6 +179,11 @@ function makeWorker(){
     if (message === 'offline') {
       // worker declared itself offline. we're treating it as
       // if it just now crashed.
+
+      // but only accept the offline message from a process that is not already
+      // dying
+      if (workerStatus[worker.process.pid] === 'dying') return
+
       expectedExit = true;
 
       setWorkerStatus(worker, 'dying');

--- a/test/server6.js
+++ b/test/server6.js
@@ -10,6 +10,12 @@ server = http.createServer(function(req, resp) {
     server.close(function() {
       setTimeout(process.exit.bind(this, 0), 200);
     });
+  } else if (req.url === "/double-offline") {
+    process.send("offline");
+    resp.end("Not really going offline");
+    setTimeout(function() {
+      process.send("offline")
+    }, 200)
   }
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -600,6 +600,59 @@ var steps = [
       });
     },
   },
+  rm(["naught.log", "stderr.log", "stdout.log"]),
+  {
+    info: "(test setup) start server6 up",
+    fn: function (cb) {
+      naughtExec(["start", "server.js"], {
+        PORT: PORT,
+        hi: "server6 says hi",
+      }, function(stdout, stderr, code) {
+        assertEqual(stderr,
+          "Bootup. booting: 0, online: 0, dying: 0, new_online: 0\n" +
+          "SpawnNew. booting: 1, online: 0, dying: 0, new_online: 0\n" +
+          "NewOnline. booting: 0, online: 0, dying: 0, new_online: 1\n");
+        assertEqual(stdout, "workers online: 1\n")
+        assertEqual(code, 0)
+        cb();
+      });
+    }
+  },
+  get("(test setup) have server send offline message without dying", "/double-offline", "Not really going offline"),
+  {
+    info: "make sure double offline message only spawns one new server",
+    fn: function (cb) {
+      // Wait for the server to go send both offline messages
+      setTimeout(function() {
+        fs.readFile(path.join(test_root, "naught.log"), "utf8", function (err, contents) {
+          assertEqual(contents,
+            "Bootup. booting: 0, online: 0, dying: 0, new_online: 0\n" +
+            "SpawnNew. booting: 1, online: 0, dying: 0, new_online: 0\n" +
+            "NewOnline. booting: 0, online: 0, dying: 0, new_online: 1\n" +
+            "Ready. booting: 0, online: 1, dying: 0, new_online: 0\n" +
+            "WorkerOffline. booting: 0, online: 0, dying: 1, new_online: 0\n" +
+            "SpawnNew. booting: 1, online: 0, dying: 1, new_online: 0\n" +
+            "WorkerOnline. booting: 0, online: 1, dying: 1, new_online: 0\n" +
+            "Ready. booting: 0, online: 1, dying: 1, new_online: 0\n"
+                     );
+          cb();
+        });
+      }, 600);
+    },
+  },
+  {
+    info: "(test setup) stopping server",
+    fn: function (cb) {
+      naughtExec(["stop"], {}, function(stdout, stderr, code) {
+        assertEqual(stderr,
+          "ShutdownOld. booting: 0, online: 0, dying: 2, new_online: 0\n" +
+          "OldExit. booting: 0, online: 0, dying: 1, new_online: 0\n");
+        assertEqual(stdout, "");
+        assertEqual(code, 0)
+        cb();
+      });
+    },
+  },
   rm(["naught.log", "stderr.log", "stdout.log", "server.js"]),
 ];
 


### PR DESCRIPTION
This prevents a dying server from being able to spawn many new workers and go over the worker-count parameter
