### PR TITLE
[FEAT] Auto worker count

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ CLI:
 
         `worker-count` can be used to change the number of workers running. A
         value of `0` means to keep the same number of workers.
+        A value of 'auto', will set value as per the number of available CPUs.
 
         `cwd` can be used to change the cwd directory of the master process.
         This allows you to release in different directories. Unfortunately,

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,6 @@ var path = require('path');
 var DEFAULT_IPC_FILE = 'naught.ipc';
 var DEFAULT_PID_FILE = 'naught.pid';
 var CWD = process.cwd();
-var cpuCount = require('os').cpus().length;
 var daemon = require('./daemon');
 
 var cmds = {
@@ -73,7 +72,7 @@ var cmds = {
       if (!err && script != null) {
         options['daemon-mode'] = options['daemon-mode'] === 'true';
         options['remove-old-ipc'] = options['remove-old-ipc'] === 'true';
-        options['worker-count'] = parseInt(options['worker-count'], 10);
+        options['worker-count'] = extendedWorkerCount(options['worker-count']);
         if (isNaN(options['worker-count'])) return false;
         options['max-log-size'] = parseInt(options['max-log-size'], 10);
         if (isNaN(options['max-log-size'])) return false;
@@ -572,4 +571,12 @@ function displayStatus(ipcFile){
       }
     }
   });
+}
+
+function extendedWorkerCount(workerCount){
+  if (workerCount === 'auto'){
+    return require('os').cpus().length;
+  } else {
+    return parseInt(workerCount, 10);
+  }
 }


### PR DESCRIPTION
@andrewrk Based on the discussion in #43 and now, the issue raised in #66 , I suggest to add an "auto" option to the worker-count, to allow the configuration of worker per CPU.
