### PR TITLE
Allow graceful restart when some processes are already dying. This fixes andrewrk/naught#68

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -288,7 +288,6 @@ function deployStart(cb){
     }
     pend.wait(function() {
       assert.strictEqual(workers.online.count, 0);
-      assert.strictEqual(workers.dying.count, 0);
       waitingFor = null;
       forEachWorker('new_online', function(pid, worker){
         setWorkerStatus(worker, 'online');

--- a/test/server8.js
+++ b/test/server8.js
@@ -1,0 +1,6 @@
+
+process.send('online')
+setTimeout(function(){
+    process.send('offline')
+}, 1000);
+


### PR DESCRIPTION
Dropping the assert does not seem to break anything. What do you think? (link: andrewrk/naught#68)