### PR TITLE
Disconnect the worker after sending message

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -247,8 +247,8 @@ function shutdownOneWorker(status){
     dyingWorker.on('exit', onExit);
     var handledOnExit = false;
     try {
-      dyingWorker.disconnect();
       dyingWorker.send('shutdown');
+      dyingWorker.disconnect();
     } catch (err) {
       onExit();
     }

--- a/test/server8.js
+++ b/test/server8.js
@@ -1,0 +1,8 @@
+var fs = require('fs')
+process.on('message', function(message) {
+  if(message == 'shutdown') {
+    fs.writeFileSync('tmp', 'shutdown')
+    process.send('offline')
+  }
+})
+process.send('online')

--- a/test/test.js
+++ b/test/test.js
@@ -699,6 +699,53 @@ var steps = [
     },
   },
   rm(["naught.log", "stderr.log", "stdout.log", "server.js"]),
+  use("server8.js"),
+  {
+    info: "(test setup) starting server",
+    fn: function(cb) {
+      naughtExec(["start", "server.js"], {}, function(stdout, stderr, code) {
+        assertEqual(stderr,
+          "Bootup. booting: 0, online: 0, dying: 0, new_online: 0\n" +
+          "SpawnNew. booting: 1, online: 0, dying: 0, new_online: 0\n" +
+          "NewOnline. booting: 0, online: 0, dying: 0, new_online: 1\n");
+        assertEqual(stdout, "workers online: 1\n");
+        assertEqual(code, 0);
+        cb();
+        assertEqual(fs.existsSync(path.join(test_root, "/tmp"), "utf8"), false)
+      });
+    }
+  },
+  {
+    info: "make sure tasks in the shutdown message handler are executed",
+    fn: function(cb) {
+      naughtExec(["deploy"], {}, function(stdout, stderr, code) {
+        assertEqual(stderr,
+          "SpawnNew. booting: 1, online: 1, dying: 0, new_online: 0\n" +
+          "NewOnline. booting: 0, online: 1, dying: 0, new_online: 1\n" +
+          "ShutdownOld. booting: 0, online: 0, dying: 1, new_online: 1\n" +
+          "OldExit. booting: 0, online: 0, dying: 0, new_online: 1\n" +
+          "done\n");
+        assertEqual(stdout, "");
+        assertEqual(code, 0)
+        assertEqual(fs.readFileSync(path.join(test_root, "/tmp"), "utf8"), "shutdown")
+        cb();
+      });
+    },
+  },
+  {
+    info: "(test setup) stopping server",
+    fn: function (cb) {
+      naughtExec(["stop"], {}, function(stdout, stderr, code) {
+        assertEqual(stderr,
+          "ShutdownOld. booting: 0, online: 0, dying: 1, new_online: 0\n" +
+          "OldExit. booting: 0, online: 0, dying: 0, new_online: 0\n");
+        assertEqual(stdout, "");
+        assertEqual(code, 0)
+        cb();
+      });
+    }
+  },
+  rm(["naught.log", "stderr.log", "stdout.log", "server.js", "tmp"]),
 ];
 
 var stepCount = steps.length;


### PR DESCRIPTION
To ensure that the message is received by the worker.

Without this patch the "shutdown" message isn't always (but is
sometimes) received by the worker, with this patch it seems to always be
received and acted upon by the worker.

I feel like this patch shouldn't be required, but I spent some time diagnosing why my shutdowns weren't being acted upon... And found that they weren't being received on a number of occasions (the majority of the time during the first "deploy", and then they were received more often subsequently). With this patch I believe they're now being received 100% of the time (or at least a lot more than they were).

I just found the fs.writeFileSync was an easy way to test it (in my actual diagnosing -- because console.log's aren't synchronous so I didn't trust it) hence I replicated it in the test... Happy not to do it that way :-)

I was using node version 0.10.38 when I found the issue and wrote the test; I also ran the test with iojs 2.0.2 and node 0.12.0; and saw failures without the fix, and the test passed with the fix. 