### PR TITLE
expose worker number as NAUGHT_WORKER in process.env

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -159,9 +159,10 @@ function onceOnline(worker, cb){
   }
 }
 
-function makeWorker(){
-  var worker = cluster.fork();
+function makeWorker(number){
+  var worker = cluster.fork({'NAUGHT_WORKER': number});
   var expectedExit = false;
+  assert(number>=0);
   worker.on('message', onMessage);
   worker.on('exit', onExit);
   if (waitingFor == null) {
@@ -189,7 +190,7 @@ function makeWorker(){
       setWorkerStatus(worker, 'dying');
       event('WorkerOffline');
 
-      addWorker('booting', makeWorker());
+      addWorker('booting', makeWorker(number));
       event('SpawnNew');
     }
   }
@@ -198,7 +199,7 @@ function makeWorker(){
     if (waitingFor != null) return;
     removeWorker(worker.process.pid);
     if (!expectedExit) {
-      addWorker('booting', makeWorker());
+      addWorker('booting', makeWorker(number));
     }
     event('WorkerDeath');
   }
@@ -217,9 +218,10 @@ function event(name){
   });
 }
 
-function spawnNew(cb){
+function spawnNew(number, cb){
+  var newWorker;
   assert(workers.booting.count < workerCount);
-  var newWorker = makeWorker();
+  newWorker = makeWorker(number);
   addWorker('booting', newWorker);
   event('SpawnNew');
   newWorker.on('exit', onExit);
@@ -272,7 +274,7 @@ function deployStart(cb){
   var pend = new Pend();
   var count = workerCount;
   for (var i = 0; i < count; i += 1) {
-    spawnNew(pend.hold());
+    spawnNew(i, pend.hold());
   }
   pend.wait(function() {
     if (workers.new_online.count !== workerCount) {

--- a/test/server10.js
+++ b/test/server10.js
@@ -1,0 +1,12 @@
+var http;
+var number = process.env.NAUGHT_WORKER;
+
+http = require("http");
+
+console.log('worker #%s', number);
+http.createServer(function (req, resp) {
+    resp.end('worker #' + number);
+}).listen(process.env.PORT, function () {
+    console.error("server10 listening");
+    process.send("online");
+});

--- a/test/test.js
+++ b/test/test.js
@@ -781,6 +781,41 @@ var steps = [
     }
   },
   rm(["naught.log", "stderr.log", "stdout.log", "server.js", "tmp"]),
+  use("server10.js"),
+  {
+    info: "Should expose worker number via process.env.NAUGHT_WORKER",
+    fn: function(cb) {
+      naughtExec(["start","--worker-count", "4", "server.js"], {}, function(stdout, stderr, code) {
+        assertEqual(fs.readFileSync("./test/stdout.log", "UTF8").split('\n').sort().splice(1).join('\n'),
+          "worker #0\n"+
+          "worker #1\n"+
+          "worker #2\n"+
+          "worker #3");
+        assertEqual(code, 0);
+        cb();
+        assertEqual(fs.existsSync(path.join(test_root, "/tmp"), "utf8"), false)
+      });
+    }
+  },
+  {
+    info: "numbers should be consistent across deploys",
+    fn: function(cb) {
+      naughtExec(["deploy"], {}, function(stdout, stderr, code) {
+        assertEqual(fs.readFileSync("./test/stdout.log", "UTF8").split('\n').sort().splice(1).join('\n'),
+          "worker #0\n"+
+          "worker #0\n"+
+          "worker #1\n"+
+          "worker #1\n"+
+          "worker #2\n"+
+          "worker #2\n"+
+          "worker #3\n"+
+          "worker #3");
+        assertEqual(code, 0)
+        cb();
+      });
+    },
+  },
+  rm(["naught.log", "stderr.log", "stdout.log", "server.js"])
 ];
 
 var stepCount = steps.length;


### PR DESCRIPTION
This PR exposes the worker number over process.env.NAUGHT_WORKER.

Why? In cluster mode `server.listen(0)` will not give you a *different* random port on each worker and I need that in order to expose some metrics for a metrics collection service.
