### PR TITLE
Add support for plugging in a script on the master process.

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -22,6 +22,7 @@ function startDaemon(argv) {
   var script = argv.shift();
   var nodeArgsStr = argv.shift();
   var pidFile = argv.shift();
+  var masterHelperScript = argv.shift();
 
   var naughtLog = null;
   var stderrLog = null;
@@ -190,7 +191,7 @@ function startDaemon(argv) {
     var nodeArgs = splitCmdLine(nodeArgsStr);
     var stdoutValue = (stdoutBehavior === 'inherit') ? process.stdout : stdoutBehavior;
     var stderrValue = (stderrBehavior === 'inherit') ? process.stderr : stderrBehavior;
-    master = spawn(process.execPath, nodeArgs.concat([path.join(__dirname, "master.js"), workerCount, script]).concat(argv), {
+    master = spawn(process.execPath, nodeArgs.concat([path.join(__dirname, "master.js"), workerCount, masterHelperScript, script]).concat(argv), {
       env: process.env,
       stdio: [process.stdin, stdoutValue, stderrValue, 'ipc'],
       cwd: process.cwd(),

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,6 +51,7 @@ var cmds = {
       "    --stderr stderr.log\n" +
       "    --max-log-size 10485760\n" +
       "    --cwd " + CWD + "\n" +
+      "    --master \n" +
       "    --daemon-mode true\n" +
       "    --remove-old-ipc false\n" +
       "    --node-args ''",
@@ -62,6 +63,7 @@ var cmds = {
         'log': 'naught.log',
         'stdout': 'stdout.log',
         'stderr': 'stderr.log',
+        'master': '',
         'max-log-size': '10485760',
         'cwd': CWD,
         'daemon-mode': 'true',
@@ -381,7 +383,8 @@ function startScript(options, script, argv){
       options['max-log-size'],
       path.resolve(CWD, script),
       options['node-args'],
-      options['pid-file']
+      options['pid-file'],
+      options['master'] ? path.resolve(CWD, options['master']): ""
     ].concat(argv);
     if (options['daemon-mode']) {
       startDaemonChild(args);

--- a/lib/master.js
+++ b/lib/master.js
@@ -4,6 +4,11 @@ var Pend = require('pend');
 
 var argv = process.argv.slice(2);
 var workerCount = parseInt(argv.shift(), 10);
+var customMasterScriptFile = argv.shift();
+var customMasterScript;
+if (customMasterScriptFile) {
+  customMasterScript = require(customMasterScriptFile);
+}
 var script = argv.shift();
 
 var own = {}.hasOwnProperty;
@@ -164,6 +169,9 @@ function makeWorker(number){
   var expectedExit = false;
   assert(number>=0);
   worker.on('message', onMessage);
+  if (customMasterScript && customMasterScript.online) {
+    customMasterScript.online(worker);
+  }
   worker.on('exit', onExit);
   if (waitingFor == null) {
     // this code activates when a server crashes during normal operations;
@@ -171,9 +179,11 @@ function makeWorker(number){
     onceOnline(worker, function(){
       setWorkerStatus(worker, 'online');
       event('WorkerOnline');
+
       if (workers.booting.count === 0) event('Ready');
     });
   }
+
   return worker;
 
   function onMessage(message){


### PR DESCRIPTION
I doubt my change is perfect yet, and lacks tests, but wanted to initiate a conversation on whether or not the ability to customize the code running in the master process could fit into the core features of naught. A very simple use case is to manage log file writing, but any place where you may want some shared state between workers this could help. Log4Js for instance has an example for clustered mode:

https://github.com/nomiddlename/log4js-node/wiki/Multiprocess

But you obviously need to support adding some code into the master process. I've done this by allow a master process script file to be passed to naught, and then requiring it in. It can export a "online" function to be notified when new workers start. Probably needs a more developed contract/API, so open to ideas on changes. It has been working well for us to support master process file logging.
