### PR TITLE
Test current node versions + test update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
+  - "4.2"
+  - "node"
 branches:
   only:
     - master

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,11 @@ var steps = [
       naughtExec(["start", "--ipc-file", "/invalid/path/foo.ipc", "server.js"], {},
           function(stdout, stderr, code)
       {
-        assertEqual(stderr, "unable to start daemon: EACCES, mkdir '/invalid'\n");
+        var errorMessages = {
+            "unable to start daemon: EACCES: permission denied, mkdir '/invalid'\n": true,
+            "unable to start daemon: EACCES, mkdir '/invalid'\n": true
+	}
+        assert(errorMessages[stderr]);
         assertEqual(stdout, "");
         assertEqual(code, 1);
         cb();


### PR DESCRIPTION
Test against 4.2 LTS and 5.x Stable. 
nvm uses `node` as a pointer to latest node.
