### PR TITLE
Allow archived logs to be compressed with `deflate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ When you run with `--daemon-mode false`, the process tree looks like this:
         --stdout stdout.log
         --stderr stderr.log
         --max-log-size 10485760
+        --log-compression-format gzip
         --cwd .
         --daemon-mode true
         --remove-old-ipc false

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -19,6 +19,7 @@ function startDaemon(argv) {
   var logStderrPath = argv.shift();
   var logStdoutPath = argv.shift();
   var maxLogSize = parseInt(argv.shift(), 10);
+  var logCompressionFormat = argv.shift();
   var script = argv.shift();
   var nodeArgsStr = argv.shift();
   var pidFile = argv.shift();
@@ -77,7 +78,7 @@ function startDaemon(argv) {
         log: null,
       });
     } else {
-      createLog(logPath, maxLogSize, function(err, logStream) {
+      createLog(logPath, maxLogSize, logCompressionFormat, function(err, logStream) {
         if (err) return cb(err);
         cb(null, {
           behavior: 'pipe',

--- a/lib/log.js
+++ b/lib/log.js
@@ -5,11 +5,21 @@ var mkdirp = require('mkdirp');
 var path = require('path');
 var EventEmitter = require('events').EventEmitter;
 var zlib = require('zlib');
+var availableLogCompressionFormats = {
+  'gzip':{
+    create: zlib.createGzip,
+    extension: '.gz'
+  },'deflate':{
+    create: zlib.createDeflate,
+    extension: '.deflate'
+  }
+}
 
 // cb(err, log)
 //   log.write(str, cb)
 //     cb(err)
-function create(filePath, maxSize, cb) {
+function create(filePath, maxSize, logCompressionFormat, cb) {
+  var compression = availableLogCompressionFormats[logCompressionFormat];
   createStream(filePath, onHaveStream);
 
   function onHaveStream(err, stream, size) {
@@ -41,16 +51,16 @@ function create(filePath, maxSize, cb) {
           createStream(filePath, function(err, newStream, newSize){
             if (err) return log.emit('error', err);
             stream.once('close', function() {
-              var gzip = zlib.createGzip();
+              var compressedStream = compression.create();
               var inp = fs.createReadStream(archiveName);
-              var out = fs.createWriteStream(archiveName + ".gz");
+              var out = fs.createWriteStream(archiveName + compression.extension);
               inp.on('error', function(err) {
                 return log.emit('error', err);
               });
               out.on('error', function(err){
                 return log.emit('error', err);
               });
-              inp.pipe(gzip).pipe(out);
+              inp.pipe(compressedStream).pipe(out);
               out.once('close', function(){
                 fs.unlink(archiveName, function(err){
                   if (err) return log.emit('error', err);

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,7 @@ var spawn = require('child_process').spawn;
 var path = require('path');
 var DEFAULT_IPC_FILE = 'naught.ipc';
 var DEFAULT_PID_FILE = 'naught.pid';
+var DEFAULT_LOG_COMPRESSION_FORMAT = 'gzip';
 var CWD = process.cwd();
 var daemon = require('./daemon');
 var packageJson = require('../package.json');
@@ -50,6 +51,7 @@ var cmds = {
       "    --stdout stdout.log\n" +
       "    --stderr stderr.log\n" +
       "    --max-log-size 10485760\n" +
+      "    --log-compression-format " + DEFAULT_LOG_COMPRESSION_FORMAT + "\n" +
       "    --cwd " + CWD + "\n" +
       "    --daemon-mode true\n" +
       "    --remove-old-ipc false\n" +
@@ -63,6 +65,7 @@ var cmds = {
         'stdout': 'stdout.log',
         'stderr': 'stderr.log',
         'max-log-size': '10485760',
+	'log-compression-format': DEFAULT_LOG_COMPRESSION_FORMAT,
         'cwd': CWD,
         'daemon-mode': 'true',
         'remove-old-ipc': 'false',
@@ -379,6 +382,7 @@ function startScript(options, script, argv){
       resolveLogPath(options.stderr),
       resolveLogPath(options.stdout),
       options['max-log-size'],
+      options['log-compression-format'],
       path.resolve(CWD, script),
       options['node-args'],
       options['pid-file']

--- a/lib/main.js
+++ b/lib/main.js
@@ -81,6 +81,7 @@ var cmds = {
         if (isNaN(options['worker-count'])) return false;
         options['max-log-size'] = parseInt(options['max-log-size'], 10);
         if (isNaN(options['max-log-size'])) return false;
+        if(!~['gzip', 'deflate'].indexOf(options['log-compression-format'])) return false;
         startScript(options, script, argv);
         return true;
       } else {


### PR DESCRIPTION
This PR adds the ability to compress logs in deflate format. This is really useful when you want to process those logs with hadoop.
